### PR TITLE
Condense step navigation for sleeker design

### DIFF
--- a/projects/shared/src/lib/step-navigation/step-navigation.css
+++ b/projects/shared/src/lib/step-navigation/step-navigation.css
@@ -1,30 +1,59 @@
-.step-navigation {
-  display: block;
-  margin-bottom: 1rem;
-}
+.step-navigation { display: block; }
 
 .step-list {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding: 0.25rem 0.5rem;
 }
 
 .step-card {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
   background: var(--md-sys-color-surface);
   color: var(--md-sys-color-on-surface);
   border: 1px solid var(--md-sys-color-outline-variant);
+  box-shadow: none;
+  cursor: pointer;
+  min-height: auto;
 }
 
 .step-card.current {
-  outline: 2px solid var(--md-sys-color-primary);
+  background: color-mix(in srgb, var(--md-sys-color-primary) 12%, transparent);
+  border-color: var(--md-sys-color-primary);
 }
 
-.step-card.completed {
-  opacity: 0.9;
+.step-card.completed { opacity: 0.85; }
+.step-card.disabled { opacity: 0.55; cursor: not-allowed; }
+
+.step-icon {
+  display: inline-flex;
+  width: 1.25rem;
+  height: 1.25rem;
+  align-items: center;
+  justify-content: center;
 }
 
-.step-card.disabled {
-  opacity: 0.6;
+.step-number {
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 600;
 }
 
-.step-connector { display: none; }
+.step-label {
+  white-space: nowrap;
+  font-size: 0.8rem;
+}
+
+.step-connector {
+  position: absolute;
+  left: -0.5rem;
+  width: 0.5rem;
+  height: 2px;
+  background: var(--md-sys-color-outline-variant);
+}

--- a/projects/shared/src/lib/step-navigation/step-navigation.html
+++ b/projects/shared/src/lib/step-navigation/step-navigation.html
@@ -1,54 +1,24 @@
 <nav class="step-navigation">
-  <div class="step-title">{{ steps[0]?.title }}</div>
   <div class="step-list">
-    <mat-card 
-      *ngFor="let step of steps; let i = index" 
+    <mat-card
+      *ngFor="let step of steps; let i = index"
       class="step-card step-item"
       [class.completed]="step.completed"
       [class.current]="step.current"
-      [class.disabled]="step.disabled">
-      
+      [class.disabled]="step.disabled"
+      [routerLink]="[{ outlets: { step: step.route } }]"
+      [attr.tabindex]="step.disabled ? -1 : 0"
+      role="link"
+      [attr.aria-disabled]="step.disabled"
+    >
       <div class="step-connector" *ngIf="i > 0"></div>
-      
-      <mat-card-header>
-        <div mat-card-avatar class="step-avatar">
-          <mat-icon *ngIf="step.completed" class="step-check">check_circle</mat-icon>
-          <mat-icon *ngIf="step.current && !step.completed" class="step-current">radio_button_checked</mat-icon>
-          <span *ngIf="!step.completed && !step.current" class="step-number">{{ i + 1 }}</span>
-        </div>
-        <mat-card-title>{{ step.title }}</mat-card-title>
-        <mat-card-subtitle>{{ step.description }}</mat-card-subtitle>
-      </mat-card-header>
-      
-      <mat-card-actions align="end" *ngIf="!step.disabled">
-        <button 
-          mat-raised-button 
-          [color]="step.current ? 'primary' : (step.completed ? 'accent' : 'basic')"
-          [routerLink]="[{ outlets: { step: step.route } }]"
-          [disabled]="step.disabled">
-          <mat-icon>
-            {{ step.current ? 'play_arrow' : (step.completed ? 'visibility' : 'start') }}
-          </mat-icon>
-          {{ step.current ? 'Continue' : (step.completed ? 'Review' : 'Start') }}
-        </button>
-      </mat-card-actions>
-      
-      <div class="step-status">
-        <mat-chip-set>
-          <mat-chip *ngIf="step.completed" class="status-chip completed">
-            <mat-icon matChipAvatar>check</mat-icon>
-            Completed
-          </mat-chip>
-          <mat-chip *ngIf="step.current && !step.completed" class="status-chip current">
-            <mat-icon matChipAvatar>schedule</mat-icon>
-            In Progress
-          </mat-chip>
-          <mat-chip *ngIf="step.disabled" class="status-chip disabled">
-            <mat-icon matChipAvatar>lock</mat-icon>
-            Locked
-          </mat-chip>
-        </mat-chip-set>
-      </div>
+
+      <span class="step-icon">
+        <mat-icon *ngIf="step.completed">check_circle</mat-icon>
+        <mat-icon *ngIf="step.current && !step.completed">radio_button_checked</mat-icon>
+        <span *ngIf="!step.completed && !step.current" class="step-number">{{ i + 1 }}</span>
+      </span>
+      <span class="step-label">{{ step.title }}</span>
     </mat-card>
   </div>
 </nav>


### PR DESCRIPTION
Condense the step navigation tracker to a sleeker, chip-like design with clickable steps.

---
<a href="https://cursor.com/background-agent?bcId=bc-48d20184-6258-41db-969e-6923d29701b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-48d20184-6258-41db-969e-6923d29701b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

