### PR TITLE
Fix lint warnings

### DIFF
--- a/projects/flock-mirage/src/app/app.config.ts
+++ b/projects/flock-mirage/src/app/app.config.ts
@@ -3,11 +3,7 @@ import {
   provideBrowserGlobalErrorListeners,
   provideZoneChangeDetection,
 } from '@angular/core';
-import {
-  provideRouter,
-  RouteReuseStrategy,
-  withRouterConfig,
-} from '@angular/router';
+import { provideRouter, RouteReuseStrategy } from '@angular/router';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideHttpClient } from '@angular/common/http';
 

--- a/projects/flock-mirage/src/app/app.routes.ts
+++ b/projects/flock-mirage/src/app/app.routes.ts
@@ -9,7 +9,6 @@ import {
   StepLayout,
   StepRoute,
   uploadValidGuard,
-  authValidGuard,
   extractArchiveResolver,
   authDeactivateGuard
 } from 'shared';

--- a/projects/flock-mirage/src/app/service/bluesky.ts
+++ b/projects/flock-mirage/src/app/service/bluesky.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { BlueSkyService, Credentials, AuthResult, ConnectionResult } from 'shared';
 import { PostRecordImpl } from '@straiforos/instagramtobluesky';
 import { environment } from '../../environments/environment';

--- a/projects/flock-mirage/src/app/service/console-logger.ts
+++ b/projects/flock-mirage/src/app/service/console-logger.ts
@@ -9,16 +9,16 @@ import { Logger } from 'shared';
   providedIn: 'root'
 })
 export class ConsoleLogger implements Logger {
-  log(message: string, object?: any): void {
+  log(message: string, object?: unknown): void {
     console.log('LOG:', message, object);
   }
-  error(message: string, object?: any): void {
+  error(message: string, object?: unknown): void {
     console.error('ERROR:', message, object);
   }
-  warn(message: string, object?: any): void {
+  warn(message: string, object?: unknown): void {
     console.warn('WARN:', message, object);
   }
-  workflow(message: string, object?: any): void {
+  workflow(message: string, object?: unknown): void {
     console.log('WORKFLOW:', message, object);
   }
   async instrument(appName: string): Promise<void> {

--- a/projects/flock-mirage/src/app/service/file-processor.ts
+++ b/projects/flock-mirage/src/app/service/file-processor.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { FileService, ValidationResult } from 'shared';
 import { environment } from '../../environments/environment';
 

--- a/projects/shared/src/lib/controls/file-upload-control/file-upload-control.ts
+++ b/projects/shared/src/lib/controls/file-upload-control/file-upload-control.ts
@@ -27,7 +27,7 @@ export class FileUploadControl implements ControlValueAccessor {
   private _value: File | null = null;
 
   // ControlValueAccessor implementation
-  onChange = (value: File | null) => {};
+  onChange = (file: File | null) => { void file; };
   onTouched = () => {};
 
   get value(): File | null {

--- a/projects/shared/src/lib/route/guards/auth-deactivate-guard.ts
+++ b/projects/shared/src/lib/route/guards/auth-deactivate-guard.ts
@@ -1,8 +1,8 @@
 import { inject } from '@angular/core';
-import { CanDeactivateFn, Router, ActivatedRoute } from '@angular/router';
+import { CanDeactivateFn } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ConfigServiceImpl, Bluesky, LOGGER, Logger, SplashScreenLoading } from '../../services';
-import { catchError, finalize, from, map, Observable, of } from 'rxjs';
+import { catchError, finalize, from, map, of } from 'rxjs';
 
 /**
  * Guard to handle authentication when navigating from the auth step
@@ -15,7 +15,6 @@ export const authDeactivateGuard: CanDeactivateFn<unknown> = (component, current
   const splashScreenLoading = inject(SplashScreenLoading);
   const configService = inject(ConfigServiceImpl);
   const blueskyService = inject(Bluesky);
-  const router = inject(Router);
 
   // Get current route data to determine next/previous steps
   const currentRouteData = currentRoute?.data;

--- a/projects/shared/src/lib/route/guards/auth-valid-guard.ts
+++ b/projects/shared/src/lib/route/guards/auth-valid-guard.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import { CanDeactivateFn, Router } from '@angular/router';
+import { CanDeactivateFn } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ConfigServiceImpl } from '../../services/config';
 
@@ -8,6 +8,7 @@ import { ConfigServiceImpl } from '../../services/config';
  * Shows a snackbar message to complete authentication before proceeding
  */
 export const authValidGuard: CanDeactivateFn<unknown> = (component) => {
+  void component;
   const configService = inject(ConfigServiceImpl);
   
   // Check if we have valid credentials stored (form was valid)

--- a/projects/shared/src/lib/route/guards/upload-valid-guard.ts
+++ b/projects/shared/src/lib/route/guards/upload-valid-guard.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import { CanDeactivateFn, Router } from '@angular/router';
+import { CanDeactivateFn } from '@angular/router';
 import { FileService, FILE_PROCESSOR } from '../../services';
 import { MatSnackBar } from '@angular/material/snack-bar';
 

--- a/projects/shared/src/lib/route/resolver/extract-archive/extract-archive-resolver.ts
+++ b/projects/shared/src/lib/route/resolver/extract-archive/extract-archive-resolver.ts
@@ -1,7 +1,7 @@
 import { inject } from '@angular/core';
 import { ResolveFn } from '@angular/router';
 import { FILE_PROCESSOR, FileService, LOGGER, Logger, SplashScreenLoading } from '../../../services';
-import { catchError, finalize, from, Observable, of, tap } from 'rxjs';
+import { catchError, finalize, from, of, tap } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 export const extractArchiveResolver: ResolveFn<Observable<boolean>> = () => {
@@ -21,7 +21,7 @@ export const extractArchiveResolver: ResolveFn<Observable<boolean>> = () => {
       }
     }),
     catchError((error) => {
-      logger.error('Error extracting archive');
+      logger.error('Error extracting archive', error);
       snackBar.open('Error extracting archive', 'Close', { duration: 3000 });
       return of(false); // Return false to indicate failure
     }),

--- a/projects/shared/src/lib/services/bluesky.ts
+++ b/projects/shared/src/lib/services/bluesky.ts
@@ -6,7 +6,7 @@ import {
   ConnectionResult,
 } from './interfaces/bluesky';
 import { PostRecordImpl } from '@straiforos/instagramtobluesky';
-import { validateBlueskyUsername, validateBlueskyUsernameWithAt } from './validators/username.validator';
+import { validateBlueskyUsernameWithAt } from './validators/username.validator';
 
 @Injectable({
   providedIn: 'root',

--- a/projects/shared/src/lib/services/instagram.ts
+++ b/projects/shared/src/lib/services/instagram.ts
@@ -7,10 +7,12 @@ import { InstagramService, ValidationResult } from '../services';
 })
 export class Instagram implements InstagramService {
   validateExportStructure(path: string): Promise<ValidationResult> {
+    void path;
     throw new Error('Method not implemented.');
   }
 
   processInstagramData(path: string): Promise<MediaProcessResult[]> {
+    void path;
     throw new Error('Method not implemented.');
   }
 }

--- a/projects/shared/src/lib/services/interfaces/file.ts
+++ b/projects/shared/src/lib/services/interfaces/file.ts
@@ -5,7 +5,7 @@ export interface ValidationResult {
   warnings: string[];
   timestamp: Date;
   field?: string;
-  value?: any;
+  value?: unknown;
 }
 
 /**

--- a/projects/shared/src/lib/services/interfaces/logger.ts
+++ b/projects/shared/src/lib/services/interfaces/logger.ts
@@ -3,22 +3,22 @@ export interface Logger {
    * Logs general information.
    * @param message The message to log.
    */
-  log(message: string, object?: any): void;
+  log(message: string, object?: unknown): void;
   /**
    * Logs error messages.
    * @param message The error message to log.
    */
-  error(message: string, object?: any): void;
+  error(message: string, object?: unknown): void;
   /**
    * Logs warning messages.
    * @param message The warning message to log.
    */
-  warn(message: string, object?: any): void;
+  warn(message: string, object?: unknown): void;
   /**
    * Logs workflow-related information.
    * @param message The workflow message to log.
    */
-  workflow(message: string, object?: any): void;
+  workflow(message: string, object?: unknown): void;
   /**
    * Configures instrumentation for specific application
    * @param message

--- a/projects/shared/src/lib/services/sentry-logger.ts
+++ b/projects/shared/src/lib/services/sentry-logger.ts
@@ -7,23 +7,32 @@ import { Logger } from './interfaces/logger';
 export class SentryLogger implements Logger {
   instrument(appName: string): Promise<void> {
     // TODO configure sentry
+    void appName;
     throw new Error('Method not implemented.');
   }
 
-  log(message: string): void {
+  log(message: string, _object?: unknown): void {
     // Implement Sentry logging logic here
+    void message;
+    void _object;
   }
 
-  error(message: string): void {
+  error(message: string, _object?: unknown): void {
     // Implement Sentry error logging logic here
+    void message;
+    void _object;
   }
 
-  warn(message: string): void {
+  warn(message: string, _object?: unknown): void {
     // Implement Sentry warning logging logic here
+    void message;
+    void _object;
   }
 
-  workflow(message: string): void {
+  workflow(message: string, _object?: unknown): void {
     // Implement Sentry workflow logging logic here
+    void message;
+    void _object;
   }
 
 }

--- a/projects/shared/src/lib/step-navigation/step-navigation.ts
+++ b/projects/shared/src/lib/step-navigation/step-navigation.ts
@@ -1,10 +1,10 @@
-import { Component, inject, Signal, signal, computed } from '@angular/core';
+import { Component, inject, Signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ActivatedRoute, ActivationEnd, Router, RouterModule } from '@angular/router';
+import { ActivationEnd, Router, RouterModule } from '@angular/router';
 import { LOGGER, Logger, StepRouteData, ConfigServiceImpl } from '../';
 import { MatButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
-import { filter, map, Observable, tap } from 'rxjs';
+import { filter, map, Observable } from 'rxjs';
 import { toSignal } from '@angular/core/rxjs-interop';
 
 @Component({

--- a/projects/shared/src/lib/steps/auth/auth.ts
+++ b/projects/shared/src/lib/steps/auth/auth.ts
@@ -123,7 +123,7 @@ export class Auth implements OnInit, OnDestroy {
    * Custom validator for username format
    * Prevents @ symbol and requires at least two dots
    */
-  private usernameFormatValidator(control: FormControl): { [key: string]: any } | null {
+  private usernameFormatValidator(control: FormControl): { [key: string]: unknown } | null {
     const value = control.value;
 
     if (!value) {

--- a/projects/shared/src/lib/steps/auth/help-dialog/help-dialog.ts
+++ b/projects/shared/src/lib/steps/auth/help-dialog/help-dialog.ts
@@ -20,7 +20,7 @@ export class HelpDialog {
 
   constructor(
     public dialogRef: MatDialogRef<HelpDialog>,
-    @Inject(MAT_DIALOG_DATA) public data: any
+    @Inject(MAT_DIALOG_DATA) public data: unknown
   ) {}
 
   onClose(): void {

--- a/projects/shared/src/lib/steps/config/config.ts
+++ b/projects/shared/src/lib/steps/config/config.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { FormControl, FormGroup, ReactiveFormsModule, Validators, AbstractControl, ValidationErrors } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, AbstractControl, ValidationErrors } from '@angular/forms';
 import { Component, inject, OnInit, OnDestroy, signal, computed, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';

--- a/projects/shared/src/lib/steps/upload/upload.ts
+++ b/projects/shared/src/lib/steps/upload/upload.ts
@@ -1,11 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Component, inject, OnInit } from '@angular/core';
-import { MatButton, MatIconButton } from '@angular/material/button';
-import { MatIcon } from '@angular/material/icon';
 import { FILE_PROCESSOR, FileService, LOGGER, Logger } from '../../services';
 import { FileUploadControl } from '../../controls/file-upload-control/file-upload-control';
-import { filter, tap } from 'rxjs/operators';
+import { tap } from 'rxjs/operators';
 
 @Component({
   selector: 'shared-upload',


### PR DESCRIPTION
Clean up lint warnings across the workspace to improve code quality and maintainability.

This PR addresses various lint warnings by removing unused imports and parameters, replacing `any` types with `unknown` for better type safety, and explicitly marking intentionally unused parameters with `void` statements. This ensures all Angular projects pass lint checks cleanly.

---
<a href="https://cursor.com/background-agent?bcId=bc-02cde419-a948-4fa5-9f34-68a24832b5ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02cde419-a948-4fa5-9f34-68a24832b5ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

