### PR TITLE
Add splash loader for native app

### DIFF
--- a/projects/flock-native/electron/splash.css
+++ b/projects/flock-native/electron/splash.css
@@ -1,0 +1,39 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+  color: #e6e6e6;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
+}
+
+.splash {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+  height: 100%;
+  -webkit-app-region: drag;
+}
+
+.logo {
+  width: 96px;
+  height: 96px;
+  filter: drop-shadow(0 4px 12px rgba(0,0,0,0.35));
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+}
+
+.subtitle {
+  margin: 0;
+  opacity: 0.8;
+  font-size: 13px;
+}

--- a/projects/flock-native/electron/splash.html
+++ b/projects/flock-native/electron/splash.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: filesystem:; style-src 'self' 'unsafe-inline';">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Flock - Loading…</title>
+  <link rel="stylesheet" href="./splash.css">
+</head>
+<body>
+  <div class="splash">
+    <img class="logo" src="../public/icon.png" alt="Flock icon">
+    <h1 class="title">Flock Native</h1>
+    <p class="subtitle">Starting up…</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Add a splash screen to the Electron app to provide a loading indicator during startup.

---
<a href="https://cursor.com/background-agent?bcId=bc-38969086-abc4-4321-afbf-2788454c4df2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38969086-abc4-4321-afbf-2788454c4df2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

